### PR TITLE
Add support for namespaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    hanami-events-cloud_pubsub (1.3.0)
+    hanami-events-cloud_pubsub (1.4.0)
       dry-configurable (~> 0.7.0)
       google-cloud-pubsub (~> 0.33.0)
       hanami-cli (>= 0.2.0)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Configure the pubsub adapter how you want (optional):
 Hanami.configure do
   environment :development do
     cloud_pubsub do |config|
-      config.pubsub = { project_id: 'emulator' }
-      config.logger = Hanami.logger
+      config.pubsub = { project_id: 'emulator' } # optional
+      config.logger = Hanami.logger # optional
+      config.namespace = :staging # optional
       # ...
     end
   end

--- a/lib/hanami/events/cloud_pubsub.rb
+++ b/lib/hanami/events/cloud_pubsub.rb
@@ -15,6 +15,8 @@ module Hanami
     module CloudPubsub
       extend Dry::Configurable
 
+      setting :namespace, reader: true
+
       setting :subscriber, reader: true do
         setting :streams, 4
         setting :threads do

--- a/lib/hanami/events/cloud_pubsub/version.rb
+++ b/lib/hanami/events/cloud_pubsub/version.rb
@@ -3,7 +3,7 @@
 module Hanami
   module Events
     module CloudPubsub
-      VERSION = '1.3.0'
+      VERSION = '1.4.0'
     end
   end
 end

--- a/spec/hanami/events/cloud_pubsub_spec.rb
+++ b/spec/hanami/events/cloud_pubsub_spec.rb
@@ -38,4 +38,10 @@ RSpec.describe Hanami::Events::CloudPubsub do
       )
     end
   end
+
+  describe '.namespace' do
+    it 'defaults to nil' do
+      expect(described_class.namespace).to eql(nil)
+    end
+  end
 end


### PR DESCRIPTION
This PR allows users to configure a namespace, which will apply to all broadcasted events and subscriptions. For example, with a namespace of `staging`, all event names with be transformed into `staging.my_event_name`. This allows for seperation between various environments when topic names are shared (i.e. within the same Google Cloud project).