### PR TITLE
Do not mutate payload with message `id`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    hanami-events-cloud_pubsub (2.1.1)
+    hanami-events-cloud_pubsub (2.1.2)
       dry-configurable (~> 0.8.0)
       google-cloud-pubsub (~> 0.34.0)
       hanami-cli (~> 0.2)
@@ -49,7 +49,7 @@ GEM
       googleauth (>= 0.6.2, < 0.10.0)
       grpc (>= 1.7.2, < 2.0)
       rly (~> 0.2.3)
-    google-protobuf (3.7.0-x86_64-linux)
+    google-protobuf (3.7.0)
     googleapis-common-protos (1.3.8)
       google-protobuf (~> 3.0)
       googleapis-common-protos-types (~> 1.0)
@@ -63,7 +63,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
-    grpc (1.19.0-x86_64-linux)
+    grpc (1.19.0)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
     grpc-google-iam-v1 (0.6.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 PATH
   remote: .
   specs:
-    hanami-events-cloud_pubsub (2.1.0)
+    hanami-events-cloud_pubsub (2.1.1)
       dry-configurable (~> 0.8.0)
       google-cloud-pubsub (~> 0.34.0)
-      hanami-cli (>= 0.2.0)
+      hanami-cli (~> 0.2)
       hanami-events (~> 0.2.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    hanami-events-cloud_pubsub (2.0.0)
+    hanami-events-cloud_pubsub (2.1.0)
       dry-configurable (~> 0.8.0)
       google-cloud-pubsub (~> 0.34.0)
       hanami-cli (>= 0.2.0)
@@ -49,7 +49,7 @@ GEM
       googleauth (>= 0.6.2, < 0.10.0)
       grpc (>= 1.7.2, < 2.0)
       rly (~> 0.2.3)
-    google-protobuf (3.7.0)
+    google-protobuf (3.7.0-x86_64-linux)
     googleapis-common-protos (1.3.8)
       google-protobuf (~> 3.0)
       googleapis-common-protos-types (~> 1.0)
@@ -63,7 +63,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
-    grpc (1.19.0)
+    grpc (1.19.0-x86_64-linux)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
     grpc-google-iam-v1 (0.6.9)

--- a/hanami-events-cloud_pubsub.gemspec
+++ b/hanami-events-cloud_pubsub.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'dry-configurable', '~> 0.8.0'
   spec.add_dependency 'google-cloud-pubsub', '~> 0.34.0'
-  spec.add_dependency 'hanami-cli', '>= 0.2.0'
+  spec.add_dependency 'hanami-cli', '~> 0.2'
   spec.add_dependency 'hanami-events', '~> 0.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/lib/hanami/events/adapter/cloud_pubsub.rb
+++ b/lib/hanami/events/adapter/cloud_pubsub.rb
@@ -96,7 +96,7 @@ module Hanami
         def topic_for(name)
           @topic_registry[name.to_s] ||= begin
             @pubsub.find_topic(name) ||
-              (CloudPubsub.auto_create_topics && @pubsub.create_topic(name)) ||
+              (Hanami::Events::CloudPubsub.auto_create_topics && @pubsub.create_topic(name)) ||
               raise(CloudPubsub::Errors::TopicNotFoundError, "no topic named: #{name}")
           end
         end

--- a/lib/hanami/events/adapter/cloud_pubsub.rb
+++ b/lib/hanami/events/adapter/cloud_pubsub.rb
@@ -92,6 +92,7 @@ module Hanami
           @serializer ||= Hanami::Events::Serializer[@serializer_type].new
         end
 
+        # rubocop:disable Metrics/LineLength
         def topic_for(name)
           @topic_registry[name.to_s] ||= begin
             @pubsub.find_topic(name) ||
@@ -99,6 +100,7 @@ module Hanami
               raise(CloudPubsub::Errors::TopicNotFoundError, "no topic named: #{name}")
           end
         end
+        # rubocop:enable Metrics/LineLength
 
         def namespaced(val, sep: '.')
           [Hanami::Events::CloudPubsub.namespace, val].compact.join(sep)

--- a/lib/hanami/events/adapter/cloud_pubsub.rb
+++ b/lib/hanami/events/adapter/cloud_pubsub.rb
@@ -82,7 +82,6 @@ module Hanami
           data = message.data
           payload = serializer.deserialize(data)
           event_name = message.attributes['event_name']
-          payload['id'] = message.attributes['id']
 
           @subscribers.each do |subscriber|
             subscriber.call(event_name, payload)

--- a/lib/hanami/events/cloud_pubsub/listener.rb
+++ b/lib/hanami/events/cloud_pubsub/listener.rb
@@ -17,6 +17,7 @@ module Hanami
                     :event_name,
                     :subscriber_opts,
                     :middleware
+        # rubocop:disable Metrics/ParameterLists
         def initialize(topic:,
                        logger:,
                        handler:,
@@ -32,6 +33,7 @@ module Hanami
           @subscriber_opts = CloudPubsub.config.subscriber.to_h.merge(subscriber_opts)
           @middleware = middleware
         end
+        # rubocop:enable Metrics/ParameterLists
 
         def register
           subscription = subscription_for(subscriber_id)

--- a/lib/hanami/events/cloud_pubsub/middleware/auto_retry.rb
+++ b/lib/hanami/events/cloud_pubsub/middleware/auto_retry.rb
@@ -14,7 +14,7 @@ module Hanami
           def call(message, args = {})
             succeeded = false
             failed = false
-            yield
+            yield(args)
             succeeded = true
           rescue StandardError => err
             failed = true

--- a/lib/hanami/events/cloud_pubsub/middleware/logging.rb
+++ b/lib/hanami/events/cloud_pubsub/middleware/logging.rb
@@ -10,9 +10,9 @@ module Hanami
             @logger = logger
           end
 
-          def call(msg, *_args)
+          def call(msg, opts = {})
             started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-            yield
+            yield(opts)
           ensure
             ended_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             seconds = ended_at - started_at

--- a/lib/hanami/events/cloud_pubsub/middleware/stack.rb
+++ b/lib/hanami/events/cloud_pubsub/middleware/stack.rb
@@ -43,11 +43,11 @@ module Hanami
           def invoke(*base_args)
             stack = entries.dup
 
-            traverse_stack = lambda do |*args|
+            traverse_stack = proc do |**opts|
               if stack.empty?
-                yield(*base_args, *args)
+                yield(*base_args, **opts)
               else
-                stack.shift.call(*base_args, *args, &traverse_stack)
+                stack.shift.call(*base_args, **opts, &traverse_stack)
               end
             end
 

--- a/lib/hanami/events/cloud_pubsub/middleware/stack.rb
+++ b/lib/hanami/events/cloud_pubsub/middleware/stack.rb
@@ -40,14 +40,14 @@ module Hanami
             @entries.shift
           end
 
-          def invoke(*base_args)
+          def invoke(message)
             stack = entries.dup
 
             traverse_stack = proc do |**opts|
               if stack.empty?
-                yield(*base_args, **opts)
+                yield(message)
               else
-                stack.shift.call(*base_args, **opts, &traverse_stack)
+                stack.shift.call(message, **opts, &traverse_stack)
               end
             end
 

--- a/lib/hanami/events/cloud_pubsub/version.rb
+++ b/lib/hanami/events/cloud_pubsub/version.rb
@@ -3,7 +3,7 @@
 module Hanami
   module Events
     module CloudPubsub
-      VERSION = '2.0.0'
+      VERSION = '2.1.0'
     end
   end
 end

--- a/lib/hanami/events/cloud_pubsub/version.rb
+++ b/lib/hanami/events/cloud_pubsub/version.rb
@@ -3,7 +3,7 @@
 module Hanami
   module Events
     module CloudPubsub
-      VERSION = '2.1.0'
+      VERSION = '2.1.1'
     end
   end
 end

--- a/lib/hanami/events/cloud_pubsub/version.rb
+++ b/lib/hanami/events/cloud_pubsub/version.rb
@@ -3,7 +3,7 @@
 module Hanami
   module Events
     module CloudPubsub
-      VERSION = '2.1.1'
+      VERSION = '2.1.2'
     end
   end
 end

--- a/spec/hanami/events/cloud_pubsub/middleware/stack_spec.rb
+++ b/spec/hanami/events/cloud_pubsub/middleware/stack_spec.rb
@@ -46,8 +46,8 @@ module Hanami
           end
 
           describe '#invoke' do
-            let(:arguments) { %i[foo bar] }
-            let(:final_call_stub) { double(call: true) }
+            let(:message) { %i[foo bar] }
+            let(:handler) { double(call: true) }
             let(:first_call_stub) { double(call: true) }
             let(:second_call_stub) { double(call: true) }
             let(:third_call_stub) { double(call: true) }
@@ -70,12 +70,12 @@ module Hanami
               stack << middleware.new(second_call_stub, test: true)
               stack << middleware.new(third_call_stub)
 
-              stack.invoke(*arguments) { |*args| final_call_stub.call(*args) }
+              stack.invoke(message) { |msg| handler.call(msg) }
 
-              expect(first_call_stub).to have_received(:call).with(*arguments, {})
-              expect(second_call_stub).to have_received(:call).with(*arguments, test: true)
-              expect(third_call_stub).to have_received(:call).with(*arguments, test: true)
-              expect(final_call_stub).to have_received(:call).with(*arguments, test: true)
+              expect(first_call_stub).to have_received(:call).with(message, {})
+              expect(second_call_stub).to have_received(:call).with(message, test: true)
+              expect(third_call_stub).to have_received(:call).with(message, test: true)
+              expect(handler).to have_received(:call).with(message)
             end
 
             it 'halts the chain if a middleware does not yield' do
@@ -83,15 +83,15 @@ module Hanami
               allow(non_yielding_middleware).to receive(:call)
 
               stack << non_yielding_middleware
-              stack.invoke(*arguments) { |*args| final_call_stub.call(*args) }
+              stack.invoke(message) { |msg| handler.call(msg) }
 
-              expect(final_call_stub).not_to have_received(:call).with(*arguments)
+              expect(handler).not_to have_received(:call).with(message)
             end
 
             it 'bubbles errors' do
               stack << proc { raise 'Oh no' }
 
-              expect { stack.invoke(*arguments) }.to raise_error 'Oh no'
+              expect { stack.invoke(message) }.to raise_error 'Oh no'
             end
           end
         end


### PR DESCRIPTION
Previously, we mutated the input payload by adding an `id` key which corresponds to the message's id. If the input to the handler already had `id` as a key, it would overwrite it, causing confusing errors. This PR changes that behavior so that we never mutate the payload.